### PR TITLE
HDDS-15390. Order same-object RENAME/MODIFY entries in SnapDiffDepend…

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapDiffDependencyGraph.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapDiffDependencyGraph.java
@@ -41,6 +41,8 @@ import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffType;
  *   <li>Non-delete entry before DELETE of its parent object.</li>
  *   <li>DELETE before CREATE/RENAME that targets the same path.</li>
  *   <li>RENAME before CREATE that reuses the rename source path.</li>
+ *   <li>For the same object, an entry at the RENAME source path before the
+ *       RENAME, and the RENAME before an entry at its target path.</li>
  * </ul>
  *
  * <p>A RENAME target path cannot match a CREATE path in the same diff report.
@@ -184,6 +186,47 @@ public final class SnapDiffDependencyGraph {
     addPathConflictEdges(deleteNodesByPath, createNodesByPath,
         renameNodesByTargetPath);
     addRenameBeforeCreateEdges(renameNodesBySourcePath, createNodesByPath);
+    addIntraObjectRenameEdges(nonDeleteNodesByObjectId);
+  }
+
+  /**
+   * Orders the non-delete entries of a single object relative to its RENAME.
+   * An entry reported at the RENAME source (from-snapshot) path must be applied
+   * before the path is renamed away; an entry reported at the RENAME target
+   * (to-snapshot) path must be applied after the rename creates that path.
+   */
+  private void addIntraObjectRenameEdges(
+      Map<Long, List<Integer>> nonDeleteNodesByObjectId) {
+    for (List<Integer> objectNodes : nonDeleteNodesByObjectId.values()) {
+      if (objectNodes.size() < 2) {
+        continue;
+      }
+      Integer renameNodeId = null;
+      for (int nodeId : objectNodes) {
+        if (nodes.get(nodeId).getDiffType() == DiffType.RENAME) {
+          renameNodeId = nodeId;
+          break;
+        }
+      }
+      if (renameNodeId == null) {
+        continue;
+      }
+      SnapDiffDependencyEntry rename = nodes.get(renameNodeId);
+      for (int nodeId : objectNodes) {
+        if (nodeId == renameNodeId) {
+          continue;
+        }
+        String path = nodes.get(nodeId).getSourcePath();
+        if (path == null) {
+          continue;
+        }
+        if (path.equals(rename.getSourcePath())) {
+          addEdge(nodeId, renameNodeId);
+        } else if (path.equals(rename.getTargetPath())) {
+          addEdge(renameNodeId, nodeId);
+        }
+      }
+    }
   }
 
   private static void addToPathIndex(Map<String, List<Integer>> pathIndex,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapDiffDependencyGraph.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapDiffDependencyGraph.java
@@ -126,6 +126,21 @@ class TestSnapDiffDependencyGraph {
   }
 
   @Test
+  void testModifyAtSourcePathOrderedBeforeRename() {
+    // Object 2 is both modified and renamed. MODIFY is reported at the
+    // from-snapshot (pre-rename) path "parent/a.txt", and RENAME moves that
+    // same path to "parent/b.txt". The content change must be applied while
+    // the path is still "parent/a.txt", so MODIFY must precede RENAME.
+    // RENAME is listed first to expose the missing intra-object edge.
+    List<SnapDiffDependencyEntry> entries = Arrays.asList(
+        entry(2L, 1L, RENAME, "parent/a.txt", "parent/b.txt"),
+        entry(2L, 1L, MODIFY, "parent/a.txt"));
+
+    List<DiffType> orderedTypes = toDiffTypes(sort(entries));
+    assertEquals(Arrays.asList(MODIFY, RENAME), orderedTypes);
+  }
+
+  @Test
   void testTopologicalSortDetectsCycle() {
     List<SnapDiffDependencyEntry> entries = Arrays.asList(
         entry(1L, 2L, CREATE, "a"),


### PR DESCRIPTION
…encyGraph

The dependency graph indexed multiple non-delete nodes per objectId (e.g. RENAME + MODIFY) but never added an edge between them, so topological sort could emit RENAME before a MODIFY reported at the from-snapshot source path. Add an intra-object edge oriented by which path the entry carries, plus a reproduction test.


Change-Id: Ib7ebd867f58b864f17ec28f61843390a34cf0705

## What changes were proposed in this pull request?
Provide a one-liner summary of the changes in the PR **Title** field above.
It should be in the form of `HDDS-1234. Short summary of the change`.

Please describe your PR in detail:
* What changes are proposed in the PR? and Why? It would be better if it is written from third person's
perspective not just for the reviewer.
* Provide as much context and rationale for the pull request as possible. It could be copy-paste from
the Jira's description if the jira is well defined.
* If it is complex code, describe the approach used to solve the issue. If possible attach design doc,
issue investigation, github discussion, etc.

Examples of well-written pull requests:
* [#3980](https://github.com/apache/ozone/pull/3980)
* [#5265](https://github.com/apache/ozone/pull/5265)
* [#4701](https://github.com/apache/ozone/pull/4701)
* [#5283](https://github.com/apache/ozone/pull/5283)
* [#5300](https://github.com/apache/ozone/pull/5300)

## What is the link to the Apache JIRA

Please create an issue in ASF JIRA before opening a pull request, and you need to set the title of the pull
request which starts with the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)

If you do not have an ASF Jira account yet, please follow the first-time contributor
instructions in the [Jira guideline](../CONTRIBUTING.md#jira-guideline).

(Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
